### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/integrations/mem0/cookbooks/mem0-autogen.ipynb
+++ b/integrations/mem0/cookbooks/mem0-autogen.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "code",
    "source": [
     "%pip install --upgrade pip\n",
-    "%pip install mem0ai pyautogen flaml"
+    "%pip install mem0ai ag2 flaml"
    ],
    "id": "1e8a980a2e0b9a85",
    "outputs": [],

--- a/integrations/mem0/docs/integrations/autogen.mdx
+++ b/integrations/mem0/docs/integrations/autogen.mdx
@@ -10,7 +10,7 @@ In this guide, we'll explore an example of creating a conversational AI system w
 Install necessary libraries:
 
 ```bash
-pip install pyautogen mem0ai openai
+pip install ag2 mem0ai openai
 ```
 
 First, we'll import the necessary libraries and set up our configurations.

--- a/integrations/mem0/mem0_temp/cookbooks/mem0-autogen.ipynb
+++ b/integrations/mem0/mem0_temp/cookbooks/mem0-autogen.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "code",
    "source": [
     "%pip install --upgrade pip\n",
-    "%pip install mem0ai pyautogen flaml"
+    "%pip install mem0ai ag2 flaml"
    ],
    "id": "1e8a980a2e0b9a85",
    "outputs": [],

--- a/integrations/mem0/mem0_temp/docs/integrations/autogen.mdx
+++ b/integrations/mem0/mem0_temp/docs/integrations/autogen.mdx
@@ -10,7 +10,7 @@ In this guide, we'll explore an example of creating a conversational AI system w
 Install necessary libraries:
 
 ```bash
-pip install pyautogen mem0ai openai
+pip install ag2 mem0ai openai
 ```
 
 First, we'll import the necessary libraries and set up our configurations.


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to replace the installation of the `pyautogen` package with `ag2` in relevant guides.

* **Chores**
  * Changed package installation commands in example notebooks to use `ag2` instead of `pyautogen`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->